### PR TITLE
Release v0.5.5

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -2,9 +2,9 @@ name: Haskell CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     # run at the start of every day
     - cron: '0 0 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5.5 (1/15/2024)
+=================
+* Fix runtime error on Windows [6](https://github.com/standardsemiconductor/serialport/pull/6)
+* Deprecate String `fdRead` [9](https://github.com/standardsemiconductor/serialport/pull/9)
+* Update to unix-2.8 [8](https://github.com/standardsemiconductor/serialport/pull/8)
+
 0.5.4 (12/02/2022)
 ==================
 * Update package dependency constraints

--- a/serialport.cabal
+++ b/serialport.cabal
@@ -1,5 +1,5 @@
 Name:           serialport
-Version:        0.5.4
+Version:        0.5.5
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
 license:        BSD3


### PR DESCRIPTION
0.5.5 (1/15/2024)
===========
* Fix runtime error on Windows [6](https://github.com/standardsemiconductor/serialport/pull/6)
* Deprecate String `fdRead` [9](https://github.com/standardsemiconductor/serialport/pull/9)
* Update to unix-2.8 [8](https://github.com/standardsemiconductor/serialport/pull/8)