### PR TITLE
Release 0.5.6

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }} 
     strategy:
       matrix:
-        ghc: ['9.0', '9.2', '9.4', '9.6']
+        ghc: ['9.0', '9.2', '9.4', '9.6', '9.8']
         os: [macos-12, ubuntu-20.04, windows-2022]
     name: ${{ matrix.os }} GHC ${{ matrix.ghc }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.5.6 (11/23/2024)
+==================
+* Add custom baud rates [13](https://github.com/standardsemiconductor/serialport/pull/13)
+* Update package dependency constraints
+
 0.5.5 (1/15/2024)
 =================
 * Fix runtime error on Windows [6](https://github.com/standardsemiconductor/serialport/pull/6)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Haskell CI](https://github.com/standardsemiconductor/serialport/actions/workflows/haskell.yml/badge.svg)](https://github.com/standardsemiconductor/serialport/actions/workflows/haskell.yml)
 [![Hackage][hackage-badge]][hackage]
-[![Hackage Dependencies][hackage-deps-badge]][hackage-deps]
 
 Cross platform (Linux, Windows and Mac OS) [serial port](https://en.wikipedia.org/wiki/Serial_port) interface.
 
@@ -22,8 +21,8 @@ withSerial port defaultSerialSettings $ \s -> do
 
 [Concurrently](https://hackage.haskell.org/package/async) read and write a serial port at 19200 [baud](https://learn.sparkfun.com/tutorials/serial-communication/rules-of-serial) using `hWithSerial`:
 ```haskell
-import Control.Concurrent.Async ( concurrently_ )
-import Control.Monad            ( forever )
+import Control.Concurrent.Async
+import Control.Monad
 import System.Hardware.Serialport
 import System.IO
 
@@ -56,7 +55,5 @@ serialPortSettings = defaultSerialSettings{ commSpeed = CS19200 }
 ### Running the tests
 * Run the tests: `cabal test --test-options="/dev/ttyACM0 /dev/ttyUSB0"`
 
-[hackage]:            <https://hackage.haskell.org/package/serialport>
-[hackage-badge]:      <https://img.shields.io/hackage/v/serialport.svg?color=success>
-[hackage-deps-badge]: <https://img.shields.io/hackage-deps/v/serialport.svg>
-[hackage-deps]:       <http://packdeps.haskellers.com/feed?needle=serialport>
+[hackage]:       <https://hackage.haskell.org/package/serialport>
+[hackage-badge]: <https://img.shields.io/hackage/v/serialport.svg?color=success>

--- a/serialport.cabal
+++ b/serialport.cabal
@@ -1,5 +1,5 @@
 Name:           serialport
-Version:        0.5.5
+Version:        0.5.6
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
 license:        BSD3
@@ -24,7 +24,7 @@ source-repository head
 Library
   Exposed-Modules:    System.Hardware.Serialport
   Other-Modules:      System.Hardware.Serialport.Types
-  Build-Depends:      base       >= 4.12 && < 4.20,
+  Build-Depends:      base       >= 4.12 && < 4.21,
                       bytestring >= 0.11 && < 0.13
   ghc-options:        -Wall -fno-warn-orphans
   default-language: Haskell2010


### PR DESCRIPTION
0.5.6 (11/23/2024)
==================
* Add custom baud rates [13](https://github.com/standardsemiconductor/serialport/pull/13)
* Update package dependency constraints