### PR TITLE
Update ubuntu CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['9.0', '9.2', '9.4', '9.6', '9.8']
-        os: [macos-13, ubuntu-20.04, windows-2022]
+        os: [macos-13, ubuntu-22.04, windows-2022]
     name: ${{ matrix.os }} GHC ${{ matrix.ghc }}
     steps:
     - name: Checkout


### PR DESCRIPTION
Upgrade to Ubuntu 22.04. 20.04 is deprecated by Github actions.