### PR TITLE
Remove non-standard `CommSpeed` constructor

### DIFF
--- a/System/Hardware/Serialport/Posix.hsc
+++ b/System/Hardware/Serialport/Posix.hsc
@@ -210,4 +210,3 @@ commSpeedToBaudRate = \case
   CS38400  -> B38400
   CS57600  -> B57600
   CS115200 -> B115200
-  CS b     -> fromIntegral b

--- a/System/Hardware/Serialport/Types.hs
+++ b/System/Hardware/Serialport/Types.hs
@@ -16,8 +16,7 @@ data CommSpeed
   | CS38400
   | CS57600
   | CS115200
-  | CS Word32
-  deriving (Show, Read, Eq)
+  deriving (Show, Read, Eq, Bounded)
 
 data StopBits = One | Two
   deriving (Show, Read, Eq, Bounded)

--- a/System/Win32/Comm.hsc
+++ b/System/Win32/Comm.hsc
@@ -230,4 +230,3 @@ commSpeedToBaudRate cs =
       CS38400 -> (#const CBR_38400)
       CS57600 -> (#const CBR_57600)
       CS115200 -> (#const CBR_115200)
-      CS b -> fromIntegral b


### PR DESCRIPTION
The custom baud rate constructor did not work.

I considered adding more discrete baud rates to the `CommSpeed` type but there is no overlap between the [`unix`](https://hackage-content.haskell.org/package/unix-2.8.7.0/docs/System-Posix-Terminal.html#t:BaudRate) package patterns and the [`winbase.h`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-dcb#members) rates.

Reverts c64a2d0c0806e92a8c9e5dd3dfefd53614053309 and addresses #19 #20