### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.6.0 (11/23/2024)
+==================
+* Remove custom baud rates [22](https://github.com/standardsemiconductor/serialport/pull/22)
+* Update package dependency constraints
+* Add `serialport` command-line executable [16](https://github.com/standardsemiconductor/serialport/pull/16)
+
 0.5.6 (11/23/2024)
 ==================
 * Add custom baud rates [13](https://github.com/standardsemiconductor/serialport/pull/13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.6.0 (11/23/2024)
+0.6.0 (11/23/2025)
 ==================
 * Remove custom baud rates [22](https://github.com/standardsemiconductor/serialport/pull/22)
 * Update package dependency constraints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-0.6.0 (11/23/2025)
+0.6.0 (9/21/2025)
 ==================
 * Remove custom baud rates [22](https://github.com/standardsemiconductor/serialport/pull/22)
 * Update package dependency constraints

--- a/serialport.cabal
+++ b/serialport.cabal
@@ -1,5 +1,5 @@
 Name:           serialport
-Version:        0.5.6
+Version:        0.6.0
 Cabal-Version:  >= 1.10
 Build-Type:     Simple
 license:        BSD3


### PR DESCRIPTION
0.6.0 (9/21/2025)
==================
* Remove custom baud rates [22](https://github.com/standardsemiconductor/serialport/pull/22)
* Update package dependency constraints
* Add `serialport` command-line executable [16](https://github.com/standardsemiconductor/serialport/pull/16)